### PR TITLE
fix: missing parenthese when decompile cast operation

### DIFF
--- a/third_party/move/tools/revela/src/decompiler/evaluator/stackless/mod.rs
+++ b/third_party/move/tools/revela/src/decompiler/evaluator/stackless/mod.rs
@@ -350,7 +350,7 @@ impl ExprNodeOperation {
                 bracket_if_binary_with_ctx(expr, Some(naming), &ctx)?
             )),
             ExprNodeOperation::Cast(ty, expr) => Ok(format!(
-                "{} as {}",
+                "({} as {})",
                 bracket_if_binary_with_ctx(expr, Some(naming), &ctx)?,
                 ty
             )),
@@ -804,7 +804,6 @@ fn check_bracket_for_binary(
         };
         let inner_precedence = match &expr.borrow().operation {
             ExprNodeOperation::Binary(op, _, _) => get_precedence(op),
-            ExprNodeOperation::Cast(..) => 3,
             _ => 1000,
         };
         Ok(if inner_precedence < parent_precedence {
@@ -828,7 +827,7 @@ fn bracket_if_binary_with_ctx(
         };
         Ok(match &expr.borrow().operation {
             ExprNodeOperation::Binary(..) => format!("({})", expr_str),
-            ExprNodeOperation::Cast(..) => format!("({})", expr_str),
+            ExprNodeOperation::Cast(..) => format!("{}", expr_str),
             _ => expr_str,
         })
     })

--- a/third_party/move/tools/revela/tests/refs/coin-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/coin-decompiled.move
@@ -71,7 +71,7 @@ module 0x1::coin {
         let v1 = &mut borrow_global_mut<CoinInfo<T0>>(coin_address<T0>()).supply;
         if (0x1::option::is_some<0x1::optional_aggregator::OptionalAggregator>(v1)) {
             let v2 = 0x1::option::borrow_mut<0x1::optional_aggregator::OptionalAggregator>(v1);
-            0x1::optional_aggregator::sub(v2, v0 as u128);
+            0x1::optional_aggregator::sub(v2, (v0 as u128));
         };
     }
     
@@ -134,7 +134,7 @@ module 0x1::coin {
         let v0 = 0x1::aggregator::read(&arg0.value);
         assert!(v0 <= 18446744073709551615, 0x1::error::out_of_range(14));
         0x1::aggregator::sub(&mut arg0.value, v0);
-        Coin<T0>{value: v0 as u64}
+        Coin<T0>{value: (v0 as u64)}
     }
     
     public fun extract<T0>(arg0: &mut Coin<T0>, arg1: u64) : Coin<T0> {
@@ -226,7 +226,7 @@ module 0x1::coin {
     
     public(friend) fun merge_aggregatable_coin<T0>(arg0: &mut AggregatableCoin<T0>, arg1: Coin<T0>) {
         let Coin { value: v0 } = arg1;
-        0x1::aggregator::add(&mut arg0.value, v0 as u128);
+        0x1::aggregator::add(&mut arg0.value, (v0 as u128));
     }
     
     public fun mint<T0>(arg0: u64, arg1: &MintCapability<T0>) : Coin<T0> acquires CoinInfo {
@@ -236,7 +236,7 @@ module 0x1::coin {
         let v0 = &mut borrow_global_mut<CoinInfo<T0>>(coin_address<T0>()).supply;
         if (0x1::option::is_some<0x1::optional_aggregator::OptionalAggregator>(v0)) {
             let v1 = 0x1::option::borrow_mut<0x1::optional_aggregator::OptionalAggregator>(v0);
-            0x1::optional_aggregator::add(v1, arg0 as u128);
+            0x1::optional_aggregator::add(v1, (arg0 as u128));
         };
         Coin<T0>{value: arg0}
     }

--- a/third_party/move/tools/revela/tests/refs/delegation_pool-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/delegation_pool-decompiled.move
@@ -373,7 +373,7 @@ module 0x1::delegation_pool {
         let v8 = if (v6 > v7) {
             let v9 = 10000;
             assert!(v9 != 0, 0x1::error::invalid_argument(4));
-            (((v6 - v7) as u128) * (arg0.operator_commission_percentage as u128) / (v9 as u128)) as u64
+            ((((v6 - v7) as u128) * (arg0.operator_commission_percentage as u128) / (v9 as u128)) as u64)
         } else {
             0
         };
@@ -381,7 +381,7 @@ module 0x1::delegation_pool {
         let v11 = if (v4 > v10) {
             let v12 = 10000;
             assert!(v12 != 0, 0x1::error::invalid_argument(4));
-            (((v4 - v10) as u128) * (arg0.operator_commission_percentage as u128) / (v12 as u128)) as u64
+            ((((v4 - v10) as u128) * (arg0.operator_commission_percentage as u128) / (v12 as u128)) as u64)
         } else {
             0
         };
@@ -513,7 +513,7 @@ module 0x1::delegation_pool {
                 assert_delegation_pool_exists(arg0);
                 let v5 = operator_commission_percentage(arg0);
                 let v6 = v2 * (10000 - v5);
-                ((arg1 as u128) * (v6 as u128) / ((v6 as u128) + ((v3 * 10000) as u128))) as u64
+                (((arg1 as u128) * (v6 as u128) / ((v6 as u128) + ((v3 * 10000) as u128))) as u64)
             } else {
                 0
             };
@@ -631,7 +631,7 @@ module 0x1::delegation_pool {
     
     public fun multiply_then_divide(arg0: u64, arg1: u64, arg2: u64) : u64 {
         assert!(arg2 != 0, 0x1::error::invalid_argument(4));
-        ((arg0 as u128) * (arg1 as u128) / (arg2 as u128)) as u64
+        (((arg0 as u128) * (arg1 as u128) / (arg2 as u128)) as u64)
     }
     
     public fun observed_lockup_cycle(arg0: address) : u64 acquires DelegationPool {

--- a/third_party/move/tools/revela/tests/refs/fixed_point32-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/fixed_point32-decompiled.move
@@ -8,7 +8,7 @@ module 0x1::fixed_point32 {
         if (arg0.value == v0) {
             return v0 >> 32
         };
-        ((v0 as u128) + 4294967296 >> 32) as u64
+        (((v0 as u128) + 4294967296 >> 32) as u64)
     }
     
     public fun create_from_rational(arg0: u64, arg1: u64) : FixedPoint32 {
@@ -17,7 +17,7 @@ module 0x1::fixed_point32 {
         let v1 = ((arg0 as u128) << 64) / v0;
         assert!(v1 != 0 || arg0 == 0, 131077);
         assert!(v1 <= 18446744073709551615, 131077);
-        FixedPoint32{value: v1 as u64}
+        FixedPoint32{value: (v1 as u64)}
     }
     
     public fun create_from_raw_value(arg0: u64) : FixedPoint32 {
@@ -27,14 +27,14 @@ module 0x1::fixed_point32 {
     public fun create_from_u64(arg0: u64) : FixedPoint32 {
         let v0 = (arg0 as u128) << 32;
         assert!(v0 <= 18446744073709551615, 131077);
-        FixedPoint32{value: v0 as u64}
+        FixedPoint32{value: (v0 as u64)}
     }
     
     public fun divide_u64(arg0: u64, arg1: FixedPoint32) : u64 {
         assert!(arg1.value != 0, 65540);
         let v0 = ((arg0 as u128) << 32) / (arg1.value as u128);
         assert!(v0 <= 18446744073709551615, 131074);
-        v0 as u64
+        (v0 as u64)
     }
     
     public fun floor(arg0: FixedPoint32) : u64 {
@@ -68,7 +68,7 @@ module 0x1::fixed_point32 {
     public fun multiply_u64(arg0: u64, arg1: FixedPoint32) : u64 {
         let v0 = (arg0 as u128) * (arg1.value as u128) >> 32;
         assert!(v0 <= 18446744073709551615, 131075);
-        v0 as u64
+        (v0 as u64)
     }
     
     public fun round(arg0: FixedPoint32) : u64 {

--- a/third_party/move/tools/revela/tests/refs/fixed_point64-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/fixed_point64-decompiled.move
@@ -6,7 +6,7 @@ module 0x1::fixed_point64 {
     public fun add(arg0: FixedPoint64, arg1: FixedPoint64) : FixedPoint64 {
         let v0 = (get_raw_value(arg0) as u256) + (get_raw_value(arg1) as u256);
         assert!(v0 <= 340282366920938463463374607431768211455, 131077);
-        create_from_raw_value(v0 as u128)
+        create_from_raw_value((v0 as u128))
     }
     
     public fun almost_equal(arg0: FixedPoint64, arg1: FixedPoint64, arg2: FixedPoint64) : bool {
@@ -19,7 +19,7 @@ module 0x1::fixed_point64 {
         if (arg0.value == v0) {
             return v0 >> 64
         };
-        ((v0 as u256) + 18446744073709551616 >> 64) as u128
+        (((v0 as u256) + 18446744073709551616 >> 64) as u128)
     }
     
     public fun create_from_rational(arg0: u128, arg1: u128) : FixedPoint64 {
@@ -27,7 +27,7 @@ module 0x1::fixed_point64 {
         let v0 = ((arg0 as u256) << 64) / (arg1 as u256);
         assert!(v0 != 0 || arg0 == 0, 131077);
         assert!(v0 <= 340282366920938463463374607431768211455, 131077);
-        FixedPoint64{value: v0 as u128}
+        FixedPoint64{value: (v0 as u128)}
     }
     
     public fun create_from_raw_value(arg0: u128) : FixedPoint64 {
@@ -37,14 +37,14 @@ module 0x1::fixed_point64 {
     public fun create_from_u128(arg0: u128) : FixedPoint64 {
         let v0 = (arg0 as u256) << 64;
         assert!(v0 <= 340282366920938463463374607431768211455, 131077);
-        FixedPoint64{value: v0 as u128}
+        FixedPoint64{value: (v0 as u128)}
     }
     
     public fun divide_u128(arg0: u128, arg1: FixedPoint64) : u128 {
         assert!(arg1.value != 0, 65540);
         let v0 = ((arg0 as u256) << 64) / (arg1.value as u256);
         assert!(v0 <= 340282366920938463463374607431768211455, 131074);
-        v0 as u128
+        (v0 as u128)
     }
     
     public fun equal(arg0: FixedPoint64, arg1: FixedPoint64) : bool {
@@ -98,7 +98,7 @@ module 0x1::fixed_point64 {
     public fun multiply_u128(arg0: u128, arg1: FixedPoint64) : u128 {
         let v0 = (arg0 as u256) * (arg1.value as u256) >> 64;
         assert!(v0 <= 340282366920938463463374607431768211455, 131075);
-        v0 as u128
+        (v0 as u128)
     }
     
     public fun round(arg0: FixedPoint64) : u128 {

--- a/third_party/move/tools/revela/tests/refs/fungible_asset-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/fungible_asset-decompiled.move
@@ -173,7 +173,7 @@ module 0x1::fungible_asset {
         let v0 = 0x1::object::object_address<T0>(arg0);
         if (exists<ConcurrentSupply>(v0)) {
             let v1 = &mut borrow_global_mut<ConcurrentSupply>(v0).current;
-            assert!(0x1::aggregator_v2::try_sub<u128>(v1, arg1 as u128), 0x1::error::out_of_range(20));
+            assert!(0x1::aggregator_v2::try_sub<u128>(v1, (arg1 as u128)), 0x1::error::out_of_range(20));
         } else {
             assert!(exists<Supply>(v0), 0x1::error::not_found(21));
             assert!(exists<Supply>(v0), 0x1::error::not_found(21));
@@ -238,7 +238,7 @@ module 0x1::fungible_asset {
         assert!(arg1 != 0, 0x1::error::invalid_argument(1));
         let v0 = 0x1::object::object_address<T0>(arg0);
         if (exists<ConcurrentSupply>(v0)) {
-            let v1 = arg1 as u128;
+            let v1 = (arg1 as u128);
             let v2 = 0x1::aggregator_v2::try_add<u128>(&mut borrow_global_mut<ConcurrentSupply>(v0).current, v1);
             assert!(v2, 0x1::error::out_of_range(5));
         } else {

--- a/third_party/move/tools/revela/tests/refs/math64-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/math64-decompiled.move
@@ -32,7 +32,7 @@ module 0x1::math64 {
         } else {
             arg0 << 32 - v0
         };
-        let v2 = v1 as u128;
+        let v2 = (v1 as u128);
         let v3 = 0;
         let v4 = 2147483648;
         while (v4 != 0) {

--- a/third_party/move/tools/revela/tests/refs/math_fixed-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/math_fixed-decompiled.move
@@ -1,18 +1,18 @@
 module 0x1::math_fixed {
     public fun sqrt(arg0: 0x1::fixed_point32::FixedPoint32) : 0x1::fixed_point32::FixedPoint32 {
-        let v0 = 0x1::math128::sqrt((0x1::fixed_point32::get_raw_value(arg0) as u128) << 32) as u64;
+        let v0 = (0x1::math128::sqrt((0x1::fixed_point32::get_raw_value(arg0) as u128) << 32) as u64);
         0x1::fixed_point32::create_from_raw_value(v0)
     }
     
     public fun exp(arg0: 0x1::fixed_point32::FixedPoint32) : 0x1::fixed_point32::FixedPoint32 {
-        let v0 = exp_raw(0x1::fixed_point32::get_raw_value(arg0) as u128) as u64;
+        let v0 = (exp_raw((0x1::fixed_point32::get_raw_value(arg0) as u128)) as u64);
         0x1::fixed_point32::create_from_raw_value(v0)
     }
     
     fun exp_raw(arg0: u128) : u128 {
         let v0 = arg0 / 2977044472;
         assert!(v0 <= 31, 0x1::error::invalid_state(1));
-        let v1 = v0 as u8;
+        let v1 = (v0 as u8);
         let v2 = arg0 % 2977044472;
         let v3 = 595528;
         let v4 = v2 / v3;
@@ -25,25 +25,25 @@ module 0x1::math_fixed {
     }
     
     public fun ln_plus_32ln2(arg0: 0x1::fixed_point32::FixedPoint32) : 0x1::fixed_point32::FixedPoint32 {
-        let v0 = 0x1::fixed_point32::get_raw_value(arg0) as u128;
-        let v1 = ((0x1::fixed_point32::get_raw_value(0x1::math128::log2(v0)) as u128) * 2977044472 >> 32) as u64;
+        let v0 = (0x1::fixed_point32::get_raw_value(arg0) as u128);
+        let v1 = (((0x1::fixed_point32::get_raw_value(0x1::math128::log2(v0)) as u128) * 2977044472 >> 32) as u64);
         0x1::fixed_point32::create_from_raw_value(v1)
     }
     
     public fun log2_plus_32(arg0: 0x1::fixed_point32::FixedPoint32) : 0x1::fixed_point32::FixedPoint32 {
-        0x1::math128::log2(0x1::fixed_point32::get_raw_value(arg0) as u128)
+        0x1::math128::log2((0x1::fixed_point32::get_raw_value(arg0) as u128))
     }
     
     public fun mul_div(arg0: 0x1::fixed_point32::FixedPoint32, arg1: 0x1::fixed_point32::FixedPoint32, arg2: 0x1::fixed_point32::FixedPoint32) : 0x1::fixed_point32::FixedPoint32 {
         let v0 = 0x1::fixed_point32::get_raw_value(arg1);
         let v1 = 0x1::fixed_point32::get_raw_value(arg2);
         assert!(v1 != 0, 0x1::error::invalid_argument(4));
-        let v2 = ((0x1::fixed_point32::get_raw_value(arg0) as u128) * (v0 as u128) / (v1 as u128)) as u64;
+        let v2 = (((0x1::fixed_point32::get_raw_value(arg0) as u128) * (v0 as u128) / (v1 as u128)) as u64);
         0x1::fixed_point32::create_from_raw_value(v2)
     }
     
     public fun pow(arg0: 0x1::fixed_point32::FixedPoint32, arg1: u64) : 0x1::fixed_point32::FixedPoint32 {
-        let v0 = pow_raw(0x1::fixed_point32::get_raw_value(arg0) as u128, arg1 as u128) as u64;
+        let v0 = (pow_raw((0x1::fixed_point32::get_raw_value(arg0) as u128), (arg1 as u128)) as u64);
         0x1::fixed_point32::create_from_raw_value(v0)
     }
     
@@ -57,9 +57,9 @@ module 0x1::math_fixed {
             };
             arg1 = arg1 >> 1;
             let v2 = (arg0 as u256) * (arg0 as u256) >> 64;
-            arg0 = v2 as u128;
+            arg0 = (v2 as u128);
         };
-        (v0 >> 32) as u128
+        ((v0 >> 32) as u128)
     }
     
     // decompiled from Move bytecode v6

--- a/third_party/move/tools/revela/tests/refs/math_fixed64-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/math_fixed64-decompiled.move
@@ -1,24 +1,24 @@
 module 0x1::math_fixed64 {
     public fun sqrt(arg0: 0x1::fixed_point64::FixedPoint64) : 0x1::fixed_point64::FixedPoint64 {
         let v0 = 0x1::fixed_point64::get_raw_value(arg0);
-        let v1 = (0x1::math128::sqrt(v0) << 32) as u256;
-        0x1::fixed_point64::create_from_raw_value((v1 + ((v0 as u256) << 64) / v1 >> 1) as u128)
+        let v1 = ((0x1::math128::sqrt(v0) << 32) as u256);
+        0x1::fixed_point64::create_from_raw_value(((v1 + ((v0 as u256) << 64) / v1 >> 1) as u128))
     }
     
     public fun exp(arg0: 0x1::fixed_point64::FixedPoint64) : 0x1::fixed_point64::FixedPoint64 {
-        let v0 = exp_raw(0x1::fixed_point64::get_raw_value(arg0) as u256) as u128;
+        let v0 = (exp_raw((0x1::fixed_point64::get_raw_value(arg0) as u256)) as u128);
         0x1::fixed_point64::create_from_raw_value(v0)
     }
     
     fun exp_raw(arg0: u256) : u256 {
         let v0 = arg0 / 12786308645202655660;
         assert!(v0 <= 63, 0x1::error::invalid_state(1));
-        let v1 = v0 as u8;
+        let v1 = (v0 as u8);
         let v2 = arg0 % 12786308645202655660;
         let v3 = 22045359733108027;
         let v4 = v2 / v3;
         let v5 = v2 % v3;
-        let v6 = pow_raw(18468802611690918839, v4 as u128);
+        let v6 = pow_raw(18468802611690918839, (v4 as u128));
         let v7 = v6 - (v6 * 219071715585908898 * v4 >> 128);
         let v8 = v7 * v5 >> 64 - v1;
         let v9 = v8 * v5 >> 64;
@@ -30,23 +30,23 @@ module 0x1::math_fixed64 {
     
     public fun ln_plus_32ln2(arg0: 0x1::fixed_point64::FixedPoint64) : 0x1::fixed_point64::FixedPoint64 {
         let v0 = 0x1::fixed_point64::get_raw_value(0x1::math128::log2_64(0x1::fixed_point64::get_raw_value(arg0)));
-        0x1::fixed_point64::create_from_raw_value(((v0 as u256) * 12786308645202655660 >> 64) as u128)
+        0x1::fixed_point64::create_from_raw_value((((v0 as u256) * 12786308645202655660 >> 64) as u128))
     }
     
     public fun log2_plus_64(arg0: 0x1::fixed_point64::FixedPoint64) : 0x1::fixed_point64::FixedPoint64 {
-        0x1::math128::log2_64(0x1::fixed_point64::get_raw_value(arg0) as u128)
+        0x1::math128::log2_64((0x1::fixed_point64::get_raw_value(arg0) as u128))
     }
     
     public fun mul_div(arg0: 0x1::fixed_point64::FixedPoint64, arg1: 0x1::fixed_point64::FixedPoint64, arg2: 0x1::fixed_point64::FixedPoint64) : 0x1::fixed_point64::FixedPoint64 {
         let v0 = 0x1::fixed_point64::get_raw_value(arg1);
         let v1 = 0x1::fixed_point64::get_raw_value(arg2);
         assert!(v1 != 0, 0x1::error::invalid_argument(4));
-        let v2 = ((0x1::fixed_point64::get_raw_value(arg0) as u256) * (v0 as u256) / (v1 as u256)) as u128;
+        let v2 = (((0x1::fixed_point64::get_raw_value(arg0) as u256) * (v0 as u256) / (v1 as u256)) as u128);
         0x1::fixed_point64::create_from_raw_value(v2)
     }
     
     public fun pow(arg0: 0x1::fixed_point64::FixedPoint64, arg1: u64) : 0x1::fixed_point64::FixedPoint64 {
-        let v0 = pow_raw(0x1::fixed_point64::get_raw_value(arg0) as u256, arg1 as u128) as u128;
+        let v0 = (pow_raw((0x1::fixed_point64::get_raw_value(arg0) as u256), (arg1 as u128)) as u128);
         0x1::fixed_point64::create_from_raw_value(v0)
     }
     

--- a/third_party/move/tools/revela/tests/refs/multi_ed25519-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/multi_ed25519-decompiled.move
@@ -99,7 +99,7 @@ module 0x1::multi_ed25519 {
     }
     
     public fun unvalidated_public_key_num_sub_pks(arg0: &UnvalidatedPublicKey) : u8 {
-        (0x1::vector::length<u8>(&arg0.bytes) / 32) as u8
+        ((0x1::vector::length<u8>(&arg0.bytes) / 32) as u8)
     }
     
     public fun unvalidated_public_key_threshold(arg0: &UnvalidatedPublicKey) : 0x1::option::Option<u8> {
@@ -115,7 +115,7 @@ module 0x1::multi_ed25519 {
     }
     
     public fun validated_public_key_num_sub_pks(arg0: &ValidatedPublicKey) : u8 {
-        (0x1::vector::length<u8>(&arg0.bytes) / 32) as u8
+        ((0x1::vector::length<u8>(&arg0.bytes) / 32) as u8)
     }
     
     public fun validated_public_key_threshold(arg0: &ValidatedPublicKey) : u8 {

--- a/third_party/move/tools/revela/tests/refs/pool_u64-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/pool_u64-decompiled.move
@@ -103,7 +103,7 @@ module 0x1::pool_u64 {
     }
     
     public fun multiply_then_divide(arg0: &Pool, arg1: u64, arg2: u64, arg3: u64) : u64 {
-        (to_u128(arg1) * to_u128(arg2) / to_u128(arg3)) as u64
+        ((to_u128(arg1) * to_u128(arg2) / to_u128(arg3)) as u64)
     }
     
     public fun new(arg0: u64) : Pool {
@@ -152,7 +152,7 @@ module 0x1::pool_u64 {
     }
     
     fun to_u128(arg0: u64) : u128 {
-        arg0 as u128
+        (arg0 as u128)
     }
     
     public fun total_coins(arg0: &Pool) : u64 {

--- a/third_party/move/tools/revela/tests/refs/pool_u64_unbound-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/pool_u64_unbound-decompiled.move
@@ -97,7 +97,7 @@ module 0x1::pool_u64_unbound {
     }
     
     public fun multiply_then_divide(arg0: &Pool, arg1: u128, arg2: u128, arg3: u128) : u128 {
-        (to_u256(arg1) * to_u256(arg2) / to_u256(arg3)) as u128
+        ((to_u256(arg1) * to_u256(arg2) / to_u256(arg3)) as u128)
     }
     
     public fun redeem_shares(arg0: &mut Pool, arg1: address, arg2: u128) : u64 {
@@ -133,7 +133,7 @@ module 0x1::pool_u64_unbound {
         if (arg0.total_coins == 0 || arg0.total_shares == 0) {
             0
         } else {
-            multiply_then_divide(arg0, arg1, to_u128(arg2), arg0.total_shares) as u64
+            (multiply_then_divide(arg0, arg1, to_u128(arg2), arg0.total_shares) as u64)
         }
     }
     
@@ -141,16 +141,16 @@ module 0x1::pool_u64_unbound {
         if (arg0.total_coins == 0 || arg3 == 0) {
             0
         } else {
-            multiply_then_divide(arg0, arg1, to_u128(arg2), arg3) as u64
+            (multiply_then_divide(arg0, arg1, to_u128(arg2), arg3) as u64)
         }
     }
     
     fun to_u128(arg0: u64) : u128 {
-        arg0 as u128
+        (arg0 as u128)
     }
     
     fun to_u256(arg0: u128) : u256 {
-        arg0 as u256
+        (arg0 as u256)
     }
     
     public fun total_coins(arg0: &Pool) : u64 {

--- a/third_party/move/tools/revela/tests/refs/ristretto255-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/ristretto255-decompiled.move
@@ -116,7 +116,7 @@ module 0x1::ristretto255 {
     }
     
     public fun new_scalar_from_u32(arg0: u32) : Scalar {
-        Scalar{data: scalar_from_u64_internal(arg0 as u64)}
+        Scalar{data: scalar_from_u64_internal((arg0 as u64))}
     }
     
     public fun new_scalar_from_u64(arg0: u64) : Scalar {

--- a/third_party/move/tools/revela/tests/refs/sources-CastOperation-test-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/sources-CastOperation-test-decompiled.move
@@ -1,0 +1,11 @@
+module 0xbadbadbad::CastOperation {
+    fun test_cast1(arg0: u64) : u256 {
+        (arg0 as u256)
+    }
+    
+    fun test_cast2(arg0: u64) : u256 {
+        ((arg0 as u128) as u256)
+    }
+    
+    // decompiled from Move bytecode v6
+}

--- a/third_party/move/tools/revela/tests/refs/stake-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/stake-decompiled.move
@@ -207,7 +207,7 @@ module 0x1::stake {
     fun calculate_rewards_amount(arg0: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64) : u64 {
         let v0 = (arg4 as u128) * (arg2 as u128);
         if (v0 > 0) {
-            ((arg0 as u128) * (arg3 as u128) * (arg1 as u128) / v0) as u64
+            (((arg0 as u128) * (arg3 as u128) * (arg1 as u128) / v0) as u64)
         } else {
             0
         }
@@ -549,7 +549,7 @@ module 0x1::stake {
         let v3 = find_validator(&v2.pending_active, arg1);
         if (0x1::option::is_some<u64>(&v3)) {
             0x1::vector::swap_remove<ValidatorInfo>(&mut v2.pending_active, 0x1::option::extract<u64>(&mut v3));
-            let v4 = get_next_epoch_voting_power(v1) as u128;
+            let v4 = (get_next_epoch_voting_power(v1) as u128);
             if (v2.total_joining_power > v4) {
                 v2.total_joining_power = v2.total_joining_power - v4;
             } else {

--- a/third_party/move/tools/revela/tests/refs/staking_config-decompiled.move
+++ b/third_party/move/tools/revela/tests/refs/staking_config-decompiled.move
@@ -62,12 +62,12 @@ module 0x1::staking_config {
             let (v3, v4) = if (0x1::fixed_point64::is_zero(v2)) {
                 (0, 1)
             } else {
-                let v5 = 0x1::fixed_point64::divide_u128(1000000 as u128, v2);
+                let v5 = 0x1::fixed_point64::divide_u128((1000000 as u128), v2);
                 let v6 = v5;
                 if (v5 > 18446744073709551615) {
                     v6 = 18446744073709551615;
                 };
-                (0x1::fixed_point64::multiply_u128(v6, v2) as u64, v6 as u64)
+                ((0x1::fixed_point64::multiply_u128(v6, v2) as u64), (v6 as u64))
             };
             (v3, v4)
         } else {

--- a/third_party/move/tools/revela/tests/sources/CastOperation-decompiled.move
+++ b/third_party/move/tools/revela/tests/sources/CastOperation-decompiled.move
@@ -1,0 +1,11 @@
+module 0xbadbadbad::CastOperation {
+    fun test_cast1(arg0: u64) : u256 {
+        (arg0 as u256)
+    }
+    
+    fun test_cast2(arg0: u64) : u256 {
+        ((arg0 as u128) as u256)
+    }
+    
+    // decompiled from Move bytecode v6
+}

--- a/third_party/move/tools/revela/tests/sources/CastOperation-test.move
+++ b/third_party/move/tools/revela/tests/sources/CastOperation-test.move
@@ -1,0 +1,9 @@
+module NamedAddr::CastOperation {
+    fun test_cast1(a: u64): u256 {
+        (a as u256)
+    }
+
+    fun test_cast2(a: u64): u256 {
+        ((a as u128) as u256)
+    }
+}


### PR DESCRIPTION
Fix issue #1

I'm not familiar with Move language. I saw this repo on my social feeds, it's great to see Vietnamese people make the project 😄

My fix is always to add parentheses to cast operation, even though it's a stand-alone expression. Not sure this is a good solution